### PR TITLE
Improve Installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@ share/*
 src/*
 *.swp
 .python-canary
+.develop-canary
 *.egg-info/*
 plan.yaml
 __pycache__
 .cache
 man/*
+lib64
+pyvenv.cfg

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ develop: .develop-canary
 
 .develop-canary: .python-canary setup.py
 	bin/python setup.py develop
-	bin/pip install nosetests
+	bin/pip install nose
 	touch .develop-canary
 
 .python-canary: requirements.txt bin/pip3

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
-install-deps: .python-canary
+develop: .develop-canary
+
+.develop-canary: .python-canary
+	bin/python setup.py develop
+	touch .develop-canary
 
 .python-canary: requirements.txt bin/pip3
 	bin/pip3 install -r requirements.txt
 	touch .python-canary
 
 bin/pip3:
-	python3 venv .
+	python3 -m venv .
 
 lint:
 	flake8 hammer_time
@@ -13,4 +17,4 @@ lint:
 test:
 	bin/nosetests hammer_time -v
 
-.PHONY: install-deps lint test
+.PHONY: lint test develop

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 develop: .develop-canary
 
-.develop-canary: .python-canary
+.develop-canary: .python-canary setup.py
 	bin/python setup.py develop
+	bin/pip install nosetests
 	touch .develop-canary
 
 .python-canary: requirements.txt bin/pip3

--- a/README.md
+++ b/README.md
@@ -9,13 +9,5 @@ designed to test charms, Hammer Time tests Juju itself.
 
 Setup
 -----
-Setup is currently ugly.  You need to manually:
-
-1. Install a virtualenv
-2. Get juju-ci-tools (lp:juju-ci-tools)
-3. Use "bin/pip $JUJU_CI_TOOLS_PATH" to install it.
-4. Get Matrix (https://github.com/juju-solutions/matrix)
-5. Use "bin/pip $MATRIX_PATH" to install it.
-6. Use bin/python setup.py develop to install Hammer Time.
-
-This will get better as packaging status improves.
+Setup is developer-oriented.  Run "make develop".  This will create a
+virtualenv with Hammer Time installed as bin/hammer-time.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-matrix
-jujupy
+git+https://github.com/juju-solutions/matrix.git@3c8785f6a82b990a1976e16a374232595f12ad0c#matrix
+bzr+lp:juju-ci-tools@1924#jujupy

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ SETUP = {
             'h-time = hammer_time.hammer_time:main',
         ]
     },
-    'install_requires': reqs,
+    # Note: requirements.txt has the correct values to install these packages.
+    'install_requires': ['matrix', 'jujupy'],
 }
 
 


### PR DESCRIPTION
This branch provides working requirements.txt for the versions the Hammer Time has tested against.

It provides the "develop" makefile target, which installs Hammer Time in a venv in "development mode".

It updates the .gitignore to support venv-style virtualenvs.

It updates the readme now that installation is less painful.