### PR TITLE
Kill mongo 2

### DIFF
--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -37,7 +37,20 @@ class AddRemoveManyMachineAction:
 def choose_machine(client):
     status = client.get_status()
     machines = list(m for m, d in status.iter_machines(containers=False))
+    if len(machines) == 0:
+        raise InvalidActionError('No machines to choose from.')
     return choice(machines)
+
+
+class RebootMachineAction:
+
+    def generate_parameters(client):
+        return {'machine_id': choose_machine(client)}
+
+    def perform(client, machine_id):
+        """Add and remove many containers using the cli."""
+        old_status = client.get_status()
+        client.juju('ssh', (machine_id, 'sudo', 'reboot'))
 
 
 class AddRemoveManyContainerAction:

--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -50,7 +50,7 @@ class RebootMachineAction:
     def perform(client, machine_id):
         """Add and remove many containers using the cli."""
         old_status = client.get_status()
-        client.juju('ssh', (machine_id, 'sudo', 'reboot'))
+        client.juju('ssh', (machine_id, 'sudo', 'reboot'), check=False)
 
 
 class AddRemoveManyContainerAction:
@@ -148,6 +148,7 @@ def default_actions():
         'add_remove_many_machines': AddRemoveManyMachineAction,
         'add_remove_many_container': AddRemoveManyContainerAction,
         'kill_mongod': KillMongoDAction,
+        'reboot_machine': RebootMachineAction,
         })
 
 

--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -35,6 +35,12 @@ class AddRemoveManyMachineAction:
 
 
 def choose_machine(client):
+    """Choose a machine from the client's model at random.
+
+    :param client: The ModelClient to get machines for.
+    :return: a machine-id.
+    :raises: InvalidActionError if there are no machines to choose from.
+    """
     status = client.get_status()
     machines = list(m for m, d in status.iter_machines(containers=False))
     if len(machines) == 0:
@@ -43,6 +49,7 @@ def choose_machine(client):
 
 
 class RebootMachineAction:
+    """Action that reboots a machine."""
 
     def generate_parameters(client):
         return {'machine_id': choose_machine(client)}
@@ -54,6 +61,7 @@ class RebootMachineAction:
 
 
 class AddRemoveManyContainerAction:
+    """Action to add many containers, then remove them."""
 
     def generate_parameters(client):
         return {'host_id': choose_machine(client)}

--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -4,7 +4,6 @@ from random import (
     shuffle,
     )
 import logging
-import time
 
 from jujupy.client import ConditionList
 from jujupy import (
@@ -80,14 +79,23 @@ class AddRemoveManyContainerAction:
 class KillMongoDAction:
     """Action to kill mongod."""
 
+    kill_script = (
+        'sudo pkill mongod;',
+        'echo -n Waiting for Mongodb to die;'
+        'while (pgrep mongod > /dev/null);', 'do',
+        '  echo -n .;'
+        '  sleep 1;',
+        'done;',
+        'echo',
+        )
+
     def generate_parameters(client):
         return {'machine_id': choose_machine(client.get_controller_client())}
 
-    def perform(client, machine_id):
+    @classmethod
+    def perform(cls, client, machine_id):
         ctrl_client = client.get_controller_client()
-        ctrl_client.juju('ssh', (machine_id, 'sudo', 'pkill', 'mongod'))
-        # The impact of killing mongod seems to be delayed.
-        time.sleep(5)
+        ctrl_client.juju('ssh', (machine_id,) + cls.kill_script)
 
 
 def parse_args():

--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -56,7 +56,6 @@ class RebootMachineAction:
 
     def perform(client, machine_id):
         """Add and remove many containers using the cli."""
-        old_status = client.get_status()
         client.juju('ssh', (machine_id, 'sudo', 'reboot'), check=False)
 
 

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -124,7 +124,10 @@ class TestKillMongoDAction(TestCase):
                 with patch('time.sleep'):
                     KillMongoDAction.perform(client, '0')
         self.assertEqual([
-            backend_call(ctrl_client, 'ssh', ('0', 'sudo', 'pkill', 'mongod')),
+            backend_call(
+                ctrl_client, 'ssh',
+                ('0',) + KillMongoDAction.kill_script
+                ),
             ], juju_mock.mock_calls)
 
 

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -14,6 +14,7 @@ from hammer_time.hammer_time import (
     Actions,
     AddRemoveManyContainerAction,
     AddRemoveManyMachineAction,
+    choose_machine,
     InvalidActionError,
     KillMongoDAction,
     NoValidActionsError,
@@ -28,6 +29,21 @@ def backend_call(client, cmd, args, model=None, check=True, timeout=None,
     return call(cmd, args, client.used_feature_flags,
                 client.env.juju_home, client._cmd_model(True, False), check,
                 timeout, extra_env, suppress_err=False)
+
+
+class TestChooseMachine(TestCase):
+
+    def test_choose_machine(self):
+        chosen = set()
+        client = fake_juju_client()
+        client.bootstrap()
+        client.juju('add-machine', ('-n', '2'))
+        for x in range(50):
+            chosen.add(choose_machine(client))
+            if chosen == {'0', '1'}:
+                break
+        else:
+            raise AssertionError('Did not choose each machine.')
 
 
 class TestAddRemoveManyMachineAction(TestCase):

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -146,11 +146,12 @@ class TestRebootMachineAction(TestCase):
         client = fake_juju_client()
         client.bootstrap()
         client.juju('add-machine', ())
+        parameters = RebootMachineAction.generate_parameters(client)
         with patch.object(client._backend, 'juju',
                           wraps=client._backend.juju) as juju_mock:
-            RebootMachineAction.perform(client, '0')
+            RebootMachineAction.perform(client, **parameters)
         self.assertEqual([
-            backend_call(client, 'ssh', ('0', 'sudo', 'reboot')),
+            backend_call(client, 'ssh', ('0', 'sudo', 'reboot'), check=False),
             ], juju_mock.mock_calls)
 
 

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -151,10 +151,19 @@ class TestRebootMachineAction(TestCase):
         parameters = RebootMachineAction.generate_parameters(client)
         with patch.object(client._backend, 'juju',
                           wraps=client._backend.juju) as juju_mock:
-            RebootMachineAction.perform(client, **parameters)
+            with patch.object(client._backend, 'get_juju_output',
+                              autospec=True,
+                              side_effect=['earlier', 'now']) as jo_mock:
+                RebootMachineAction.perform(client, **parameters)
         self.assertEqual([
             backend_call(client, 'ssh', ('0', 'sudo', 'reboot'), check=False),
             ], juju_mock.mock_calls)
+        expected_call = call(
+            'ssh', ('0', 'uptime', '-s'),
+            client.used_feature_flags, client.env.juju_home,
+            client._cmd_model(True, False),
+            user_name='admin')
+        self.assertEqual([expected_call, expected_call], jo_mock.mock_calls)
 
 
 class FixedOrderActions(Actions):

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -47,7 +47,6 @@ class TestChooseMachine(TestCase):
             raise AssertionError('Did not choose each machine.')
 
     def test_no_machines(self):
-        chosen = set()
         client = fake_juju_client()
         client.bootstrap()
         with self.assertRaises(InvalidActionError):


### PR DESCRIPTION
This branch adds actions for killing MongoDB and for rebooting a machine.  It also extracts choose_machine from AddRemoveManyContainerAction.generate_parameters