### PR TITLE
Add remove-unit to Hammer Time tests

### DIFF
--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -56,7 +56,6 @@ class RebootMachineAction:
 
     def perform(client, machine_id):
         """Add and remove many containers using the cli."""
-        old_status = client.get_status()
         client.juju('ssh', (machine_id, 'sudo', 'reboot'), check=False)
 
 
@@ -91,6 +90,22 @@ class KillMongoDAction:
         time.sleep(5)
 
 
+class AddUnitAction:
+    """Add a unit to a random application."""
+
+    def generate_parameters(client):
+        """Select a random application to add a unit to."""
+        status = client.get_status()
+        applications = list(status.get_applications())
+        if len(applications) == 0:
+            raise InvalidActionError('No applications to choose from.')
+        return {'application': choice(applications)}
+
+    def perform(client, application):
+        """Add a unit to an application."""
+        client.juju('add-unit', application)
+
+
 def parse_args():
     """Parse the arguments of this script."""
     parser = ArgumentParser()
@@ -102,6 +117,13 @@ def parse_args():
     plan.set_defaults(func=random_plan)
     plan.add_argument('plan_file', help='The file to write to.')
     plan.add_argument('--juju-data', help='Location of JUJU_DATA.')
+    plan.add_argument('--force-action',
+                      help='Force the plan to use this action.',
+                      choices={
+                          k for k, v in
+                          default_actions().list_arbitrary_actions()
+                          }
+                      )
     plan.add_argument(
         '--action-count', help='Number of actions in the plan.  (default: 1)',
         default=1, type=int)
@@ -155,12 +177,13 @@ def default_actions():
     return Actions({
         'add_remove_many_machines': AddRemoveManyMachineAction,
         'add_remove_many_container': AddRemoveManyContainerAction,
+        'add_unit': AddUnitAction,
         'kill_mongod': KillMongoDAction,
         'reboot_machine': RebootMachineAction,
         })
 
 
-def random_plan(plan_file, juju_data, action_count):
+def random_plan(plan_file, juju_data, action_count, force_action):
     """Implement 'random-plan' subcommand.
 
     This writes a randomly-generated plan file.
@@ -171,6 +194,8 @@ def random_plan(plan_file, juju_data, action_count):
     client = client_for_existing(None, juju_data)
     plan = []
     actions = default_actions()
+    if force_action is not None:
+        actions = Actions({force_action: actions._actions[force_action]})
     for step in range(action_count):
         name, action, parameters = actions.generate_step(client)
         plan.append({name: parameters})

--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -147,6 +147,8 @@ class RemoveUnitAction:
     def perform(client, unit):
         """Add a unit to an application."""
         status = client.get_status()
+        # It would be nice to use Status.get_unit, but it does not yet support
+        # Python 3.
         for i_unit, data in status.iter_units():
             if i_unit == unit:
                 unit_machine = data['machine']

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -14,6 +14,7 @@ from hammer_time.hammer_time import (
     Actions,
     AddRemoveManyContainerAction,
     AddRemoveManyMachineAction,
+    AddUnitAction,
     choose_machine,
     InvalidActionError,
     KillMongoDAction,
@@ -47,7 +48,6 @@ class TestChooseMachine(TestCase):
             raise AssertionError('Did not choose each machine.')
 
     def test_no_machines(self):
-        chosen = set()
         client = fake_juju_client()
         client.bootstrap()
         with self.assertRaises(InvalidActionError):
@@ -153,6 +153,42 @@ class TestRebootMachineAction(TestCase):
         self.assertEqual([
             backend_call(client, 'ssh', ('0', 'sudo', 'reboot'), check=False),
             ], juju_mock.mock_calls)
+
+
+class TestAddUnitAction(TestCase):
+
+    def test_generate_parameters(self):
+        client = fake_juju_client()
+        client.bootstrap()
+        with self.assertRaisesRegex(InvalidActionError,
+                                    'No applications to choose from.'):
+            AddUnitAction.generate_parameters(client)
+        client.deploy('app1')
+        client.deploy('app2')
+        parameter_variations = set()
+        for count in range(50):
+            parameter_variations.add(
+                tuple(AddUnitAction.generate_parameters(client).items()))
+            if parameter_variations == {
+                        (('application', 'app1'),),
+                        (('application', 'app2'),),
+                    }:
+                break
+        else:
+            raise AssertionError(
+                'One of the expected apps was never selected.')
+
+    def test_perform_action(self):
+        client = fake_juju_client()
+        client.bootstrap()
+        client.deploy('app1')
+        parameters = AddUnitAction.generate_parameters(client)
+        AddUnitAction.perform(client, **parameters)
+        status = client.get_status()
+        self.assertEqual(
+            {'app1/0', 'app1/1'},
+            {u for u, d in status.iter_units()},
+            )
 
 
 class FixedOrderActions(Actions):
@@ -261,12 +297,24 @@ class TestRandomPlan(TestCase):
                 plan_file = os.path.join(plan_dir, 'asdf.yaml')
                 with patch('hammer_time.hammer_time.default_actions',
                            autospec=True, return_value=actions):
-                    random_plan(plan_file, 'fasd', 2)
+                    random_plan(plan_file, 'fasd', 2, None)
                 with open(plan_file) as f:
                     plan = yaml.load(f)
         cfe_mock.assert_called_once_with(None, 'fasd')
         self.assertEqual(plan, [
             {'one': {'foo': 'bar'}}, {'one': {'foo': 'bar'}}])
+
+    def test_random_plan_force_action(self):
+        cur_client = fake_juju_client()
+        with patch('hammer_time.hammer_time.client_for_existing',
+                   return_value=cur_client, autospec=True):
+            with temp_dir() as plan_dir:
+                plan_file = os.path.join(plan_dir, 'asdf.yaml')
+                random_plan(plan_file, 'fasd', 1, 'add_remove_many_machines')
+                with open(plan_file) as f:
+                    plan = yaml.load(f)
+        self.assertEqual(plan, [
+            {'add_remove_many_machines': {}}])
 
 
 class TestRunPlan(TestCase):


### PR DESCRIPTION
This branch adds support for remove-unit tests.

Removing units (and machines) is trickier than most operations, because you need to wait specifically for the machine to go away.  `ModelClient.wait_for_started` does not work for this case.

So now, `perform` methods may optionally return `Condition` instances, and `ModelClient.wait_for` will be called on them.  

Also, since the vast majority of generate_parameter methods used `Status` objects, this is now provided as a parameter, and as input into `choose_machine`.