### PR TITLE
Add interrupt_network action.

### DIFF
--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -7,6 +7,7 @@ from unittest.mock import (
     patch,
     )
 
+from jujupy import Status
 from jujupy.fake import fake_juju_client
 from jujupy.utility import temp_dir
 import yaml
@@ -185,9 +186,13 @@ class TestInterruptNetworkAction(TestCase):
         client = fake_juju_client()
         client.bootstrap()
         client.juju('add-machine', ())
+        status = Status({'machines': {'0': {'juju-status': {
+            'current': 'down',
+            }}}}, '')
         with patch.object(client._backend, 'juju',
                           wraps=client._backend.juju) as juju_mock:
-            perform(InterruptNetworkAction, client)
+            with patch.object(client, 'get_status', return_value=status):
+                perform(InterruptNetworkAction, client)
         self.assertEqual([
             backend_call(
                 client, 'ssh',

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -20,6 +20,7 @@ from hammer_time.hammer_time import (
     InvalidActionError,
     KillJujuDAction,
     KillMongoDAction,
+    MachineAction,
     NoValidActionsError,
     random_plan,
     RebootMachineAction,
@@ -85,7 +86,7 @@ class TestAddRemoveManyContainerAction(TestCase):
         client.juju('add-machine', ())
         with patch.object(client._backend, 'juju',
                           wraps=client._backend.juju) as juju_mock:
-            AddRemoveManyContainerAction.perform(client, '0')
+            perform(AddRemoveManyContainerAction, client)
         self.assertEqual([
             backend_call(client, 'add-machine', ('lxd:0')),
             backend_call(client, 'add-machine', ('lxd:0')),
@@ -113,14 +114,6 @@ def perform(cls, client):
 
 
 class TestKillJujuDAction(TestCase):
-
-    def test_generate_parameters(self):
-        client = fake_juju_client()
-        client.bootstrap()
-        client.juju('add-machine', ())
-        parameters = KillJujuDAction.generate_parameters(
-            client, client.get_status())
-        self.assertEqual(parameters, {'machine_id': '0'})
 
     def test_perform(self):
         client = fake_juju_client()
@@ -169,20 +162,23 @@ class TestKillMongoDAction(TestCase):
             ], juju_mock.mock_calls)
 
 
-class TestRebootMachineAction(TestCase):
+class TestMachineAction(TestCase):
 
     def test_generate_parameters(self):
         client = fake_juju_client()
         client.bootstrap()
         with self.assertRaises(InvalidActionError):
-            parameters = RebootMachineAction.generate_parameters(
+            parameters = MachineAction.generate_parameters(
                 client, client.get_status())
 
         client.juju('add-machine', ('-n', '2'))
         client.remove_machine('0')
-        parameters = RebootMachineAction.generate_parameters(
+        parameters = MachineAction.generate_parameters(
             client, client.get_status())
         self.assertEqual(parameters, {'machine_id': '1'})
+
+
+class TestRebootMachineAction(TestCase):
 
     def test_perform(self):
         client = fake_juju_client()


### PR DESCRIPTION
This branch adds an `interrupt_network` action that
- Disables network activity on the target machine for 5 minutes
- Waits until juju notices that the machine is down, so that the health check doesn't pass prematurely.

Note that unlike chaos monkey, this uses iptables directly, not ufw.  This is because ufw operates on a connection level, affecting only new connections, while we want to operate on a packet level, making sure nothing at all gets through.

It also extracts MachineAction from RebootMachineAction, so that Actions that operate on a machine need not define their own copy of get_parameters.

It also updates TestAddRemoveManyContainerAction to ensure that get_parameters output is compatible with perform.