### PR TITLE
Ensure we run health checks before and after run-random, like replay

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,6 @@
 import os
 from setuptools import setup, find_packages
 
-this_dir = os.path.abspath(os.path.dirname(__file__))
-reqs_file = os.path.join(this_dir, 'requirements.txt')
-with open(reqs_file) as f:
-    reqs = [line for line in f.read().splitlines()
-            if not line.startswith('--')]
-
 SETUP = {
     'name': "hammer-time",
     'packages': find_packages(),
@@ -14,7 +8,6 @@ SETUP = {
     'entry_points': {
         'console_scripts': [
             'hammer-time = hammer_time.hammer_time:main',
-            'h-time = hammer_time.hammer_time:main',
         ]
     },
     # Note: requirements.txt has the correct values to install these packages.


### PR DESCRIPTION
This branch adds checking wait_for_started to the beginning and end of run_random, matching what's done with replay.

Although it doesn't handle exceptions or resources, it does have a start and end operation, so it's factored out as a contextmanager.



