### PR TITLE
Skip windows on unixy operations

### DIFF
--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -72,6 +72,8 @@ class MachineAction:
 class RebootMachineAction(MachineAction):
     """Action that reboots a machine."""
 
+    skip_windows = True
+
     def get_up_since(client, machine_id):
         """Return the date the machine has been up since."""
         return client.get_juju_output('ssh', machine_id, 'uptime', '-s')
@@ -96,6 +98,8 @@ class RebootMachineAction(MachineAction):
 class AddRemoveManyContainerAction(MachineAction):
     """Action to add many containers, then remove them."""
 
+    skip_windows = True
+
     def perform(client, machine_id):
         """Add and remove many containers using the cli."""
         old_status = client.get_status()
@@ -110,6 +114,8 @@ class AddRemoveManyContainerAction(MachineAction):
 
 class KillJujuDAction(MachineAction):
     """Action to kill jujud."""
+
+    skip_windows = True
 
     kill_script = (
         'set -eu;',
@@ -152,6 +158,8 @@ class KillMongoDAction:
 
 
 class InterruptNetworkAction(MachineAction):
+
+    skip_windows = True
 
     def get_command():
         deny_all = '; '.join([

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -66,6 +66,20 @@ class TestChooseMachine(TestCase):
         with self.assertRaises(InvalidActionError):
             choose_machine(status)
 
+    def test_skip_windows(self):
+        status = Status({'machines': {
+            '0': {'series': 'winfoo'},
+            '1': {'series': 'angsty'},
+            }}, '')
+        for x in range(50):
+            if choose_machine(status, skip_windows=True) == '0':
+                raise AssertionError('Chose windows machine.')
+        status_2 = Status({'machines': {
+            '0': {'series': 'winfoo'},
+            }}, '')
+        with self.assertRaises(InvalidActionError):
+            choose_machine(status_2, skip_windows=True)
+
 
 class TestMachineAction(TestCase):
 
@@ -80,6 +94,25 @@ class TestMachineAction(TestCase):
         client.remove_machine('0')
         parameters = MachineAction.generate_parameters(
             client, client.get_status())
+        self.assertEqual(parameters, {'machine_id': '1'})
+
+    def test_generate_parameters_no_windows(self):
+
+        class MachineActionNoWindows(MachineAction):
+
+            skip_windows = True
+
+        status = Status({'machines': {
+            '1': {'series': 'winfoo'},
+            }}, '')
+        with self.assertRaises(InvalidActionError):
+            parameters = MachineActionNoWindows.generate_parameters(
+                None, status)
+        status_2 = Status({'machines': {
+            '1': {'series': 'wifoo'},
+            }}, '')
+        parameters = MachineActionNoWindows.generate_parameters(
+            None, status_2)
         self.assertEqual(parameters, {'machine_id': '1'})
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-bzr+lp:juju-ci-tools@1934#jujupy
+bzr+lp:juju-ci-tools@1941#jujupy


### PR DESCRIPTION
This branch adds the ability to skip windows machines when generating unixy actions.

Currently, all per-machine actions are unixy.  They use lxd, or `pkill`, or `reboot`.  This branch causes Hammer Time to skip windows machines when determining which machine to perform the operation on.  If no suitable machine can be found, a different action will used.

Machines are considered "windows" if their series starts with "win".

Now that series is heavily used, the fake must support it, so we update to the latest jujupy.