### PR TITLE
Juju data default

### DIFF
--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -14,6 +14,7 @@ from jujupy.client import (
     )
 from jujupy import (
     client_for_existing,
+    get_juju_data,
     )
 from jujupy.utility import until_timeout
 import yaml
@@ -377,6 +378,8 @@ def run_plan(plan, client):
 
 @contextmanager
 def checked_client(juju_bin, juju_data):
+    if juju_data is None:
+        juju_data = get_juju_data()
     client = client_for_existing(juju_bin, juju_data)
     # Ensure the model is healthy before beginning.
     client.wait_for_started()

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -669,13 +669,20 @@ class TestRunPlan(TestCase):
 
 class TestCheckedClient(TestCase):
 
-    def test_juju_data(self):
+    def test_juju_data_default(self):
         with patch.object(ht, 'client_for_existing') as cfe_mock:
             with patch.dict(os.environ, {'JUJU_DATA': 'bar'}):
                 with checked_client('foo', None) as client:
                     pass
         self.assertIs(client, cfe_mock.return_value)
         cfe_mock.assert_called_once_with('foo', 'bar')
+
+    def test_juju_data_supplied(self):
+        with patch.object(ht, 'client_for_existing') as cfe_mock:
+            with patch.dict(os.environ, {'JUJU_DATA': 'bar'}):
+                with checked_client('foo', 'qux'):
+                    pass
+        cfe_mock.assert_called_once_with('foo', 'qux')
 
 
 class TestReplay(TestCase):


### PR DESCRIPTION
This branch uses get_juju_data when the supplied juju_data is None.  This makes the --juju-data option truly optional.