### PR TITLE
Skip AddRemoveManyContainerAction if provider is lxd.

### DIFF
--- a/hammer_time/hammer_time.py
+++ b/hammer_time/hammer_time.py
@@ -104,6 +104,13 @@ class AddRemoveManyContainerAction(MachineAction):
 
     skip_windows = True
 
+    @staticmethod
+    def generate_parameters(client, status):
+        if client.env.provider == 'lxd':
+            raise InvalidActionError('Not supported on LXD provider.')
+        # Can't use super in a staticmethod
+        return MachineAction.generate_parameters(client, status)
+
     def perform(client, machine_id):
         """Add and remove many containers using the cli."""
         old_status = client.get_status()

--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -8,7 +8,10 @@ from unittest.mock import (
     patch,
     )
 
-from jujupy import Status
+from jujupy import (
+    JujuData,
+    Status,
+    )
 from jujupy.client import ProvisioningError
 from jujupy.fake import (
     fake_juju_client,
@@ -141,6 +144,16 @@ class TestAddRemoveManyMachineAction(TestCase):
 
 
 class TestAddRemoveManyContainerAction(TestCase):
+
+    def test_generate_parameters_lxd(self):
+        client = fake_juju_client(env=JujuData(
+            'steve', config={'type': 'lxd'}))
+        client.bootstrap()
+        client.juju('add-machine', ())
+        with self.assertRaisesRegex(InvalidActionError,
+                                    'Not supported on LXD provider.'):
+            AddRemoveManyContainerAction.generate_parameters(
+                client, client.get_status())
 
     def test_add_remove_many_container(self):
         client = fake_juju_client()


### PR DESCRIPTION
This branch fixes issue #19.

It skips AddRemoveContainer if the provider is lxd.

The default ubuntu configuration does not support nested LXD, so Hammer Time should not try to do it.