### PR TITLE
Update jujupy every time requirements.txt changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ develop: .develop-canary
 	touch .develop-canary
 
 .python-canary: requirements.txt bin/pip3
+	# When we update revno, pip doesn't consider it an upgrade.  So force a
+	# reinstall.
+	./remove-jujupy
 	bin/pip3 install -r requirements.txt
 	touch .python-canary
 

--- a/remove-jujupy
+++ b/remove-jujupy
@@ -1,0 +1,4 @@
+#!/bin/sh
+if bin/pip3 freeze|grep jujupy; then
+    bin/pip3 uninstall jujupy -y
+fi


### PR DESCRIPTION
This branch causes jujupy to be reinstalled whenever requirements.txt changes.

Hammer Time specifies jujupy by revno, not by version.  Updating the revno does not trigger an upgrade if the version is unchanged.  This branch causes jujupy to be uninstalled when requirements.txt changes, so that if the revno has changed, a new revision will be installed.