### PR TITLE
Max 10 containers, min 1.

### DIFF
--- a/hammer_time/tests/test_hammer_time.py
+++ b/hammer_time/tests/test_hammer_time.py
@@ -188,6 +188,30 @@ class TestAddRemoveManyContainerAction(TestCase):
             'machine_id': '0', 'container_count': 3,
             }, params)
 
+    def test_generate_parameters_container_max_10(self):
+        client = fake_juju_client(env=JujuData(
+            'steve', config={'type': 'not-lxd', 'region': 'asdf'}))
+        client.bootstrap()
+        client.juju('add-machine', ())
+        status = client.get_status()
+        set_hardware(status.status['machines']['0'], root_disk=32768)
+        params = AddRemoveManyContainerAction.generate_parameters(
+            client, status)
+        self.assertEqual({
+            'machine_id': '0', 'container_count': 10,
+            }, params)
+
+    def test_generate_parameters_container_max_10(self):
+        client = fake_juju_client(env=JujuData(
+            'steve', config={'type': 'not-lxd', 'region': 'asdf'}))
+        client.bootstrap()
+        client.juju('add-machine', ())
+        status = client.get_status()
+        set_hardware(status.status['machines']['0'], root_disk=2048)
+        with self.assertRaisesRegex(InvalidActionError,
+                                    'No space for containers.'):
+            AddRemoveManyContainerAction.generate_parameters(client, status)
+
     def test_add_remove_many_container(self):
         client = fake_juju_client()
         client.bootstrap()


### PR DESCRIPTION
This branch adjust the minimum and maximum containers for AddRemoveManyContainerAction.

It restricts the maximum to 10, because there's a kernel limitation of 13.

It restricts the minimum to 1, because 0 would be a no-op.